### PR TITLE
Replace robot.emit with msg.send, per changes in hubot-slack-adapter

### DIFF
--- a/src/slack-github-issue-link.coffee
+++ b/src/slack-github-issue-link.coffee
@@ -155,7 +155,4 @@ module.exports = (robot) ->
       # need to figure out how to exclude public issues
 
       attachment = makeAttachment(obj, type, repo_name)
-      robot.emit 'slack-attachment',
-        message:
-          room: msg.message.room
-        content: attachment
+      msg.send text: 'GitHub Info', attachments: [attachment]


### PR DESCRIPTION
Hi! Attachments we're failing to get sent to Slack, it was caused by a change in https://github.com/slackhq/hubot-slack. Attachments are now sent via `msg.send` instead of `robot.emit 'slack-attachment'`.
